### PR TITLE
Corrected links in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 This project uses a ESP32-Cam connected to a motion sensor. When the motion sensor is activated, a photo will be submitted to a desired Discord channel via a webhook.
 
 ## Parts needed
-- [ESP32-Cam](https://amzn.to/2N6Itsb)
-- [PIR Motion Sensor](https://amzn.to/3oX2T48)
+- [ESP32-Cam](https://amzn.to/3oX2T48)
+- [PIR Motion Sensor](https://amzn.to/2N6Itsb)
 
 ## Installation
 1. Connect PIR sensor as referenced in the diagram below.


### PR DESCRIPTION
Switched Amazon-links to the correct parts. Before the text wouldn't match the correct productpage. 